### PR TITLE
暗号化用関数を追加

### DIFF
--- a/docs/api-endpoint.md
+++ b/docs/api-endpoint.md
@@ -51,7 +51,7 @@ Request Body:
   "encrypted-key-digest": "string",
   "sign": { // 署名
     "is": true | false,
-    "sign-key": "string",
+    "signature": "string",
     "sign-key-digest": "string",
   }
 }

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "dev": "next dev --turbopack",
     "build": "next build",
     "start": "next start",
-    "lint": "next lint"
+    "type-check": "tsc --noEmit"
   },
   "dependencies": {
     "react": "^19.0.0",

--- a/src/lib/arrbuf-b64.ts
+++ b/src/lib/arrbuf-b64.ts
@@ -3,7 +3,7 @@
 /**
  * ArrayBufferをbase64にencodeする
  */
-function arrayBufferToBase64(buffer: ArrayBuffer): string {
+export function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const str = String.fromCharCode.apply(
     null,
     new Uint8Array(buffer) as unknown as number[],
@@ -12,11 +12,12 @@ function arrayBufferToBase64(buffer: ArrayBuffer): string {
   return window.btoa(str);
 }
 
-/**
- * 公開鍵をbase64にencodeする
- */
-async function publicKeyToBase64(publicKey: CryptoKey): Promise<string> {
-  const key = await window.crypto.subtle.exportKey('spki', publicKey);
-
-  return arrayBufferToBase64(key);
+export function base64ToArrayBuffer(base64: string): ArrayBuffer {
+  const str = window.atob(base64)
+  const buf = new ArrayBuffer(str.length)
+  const bufView = new Uint8Array(buf)
+  for (let i = 0, strLen = str.length; i < strLen; i++) {
+    bufView[i] = str.charCodeAt(i)
+  }
+  return buf
 }

--- a/src/lib/arrbuf-b64.ts
+++ b/src/lib/arrbuf-b64.ts
@@ -1,0 +1,22 @@
+// By https://zenn.dev/spacemarket/articles/9357ba7de0c9d3
+
+/**
+ * ArrayBufferをbase64にencodeする
+ */
+function arrayBufferToBase64(buffer: ArrayBuffer): string {
+  const str = String.fromCharCode.apply(
+    null,
+    new Uint8Array(buffer) as unknown as number[],
+  );
+
+  return window.btoa(str);
+}
+
+/**
+ * 公開鍵をbase64にencodeする
+ */
+async function publicKeyToBase64(publicKey: CryptoKey): Promise<string> {
+  const key = await window.crypto.subtle.exportKey('spki', publicKey);
+
+  return arrayBufferToBase64(key);
+}

--- a/src/lib/arrbuf-b64.ts
+++ b/src/lib/arrbuf-b64.ts
@@ -6,11 +6,11 @@ export function arrayBufferToBase64(buffer: ArrayBuffer): string {
     new Uint8Array(buffer) as unknown as number[],
   );
 
-  return window.btoa(str);
+  return globalThis.btoa(str);
 }
 
 export function base64ToArrayBuffer(base64: string): ArrayBuffer {
-  const str = window.atob(base64)
+  const str = globalThis.atob(base64)
   const buf = new ArrayBuffer(str.length)
   const bufView = new Uint8Array(buf)
   for (let i = 0, strLen = str.length; i < strLen; i++) {

--- a/src/lib/arrbuf-b64.ts
+++ b/src/lib/arrbuf-b64.ts
@@ -1,8 +1,5 @@
 // By https://zenn.dev/spacemarket/articles/9357ba7de0c9d3
 
-/**
- * ArrayBufferをbase64にencodeする
- */
 export function arrayBufferToBase64(buffer: ArrayBuffer): string {
   const str = String.fromCharCode.apply(
     null,

--- a/src/lib/arrbuf-plain.ts
+++ b/src/lib/arrbuf-plain.ts
@@ -1,7 +1,7 @@
-export async function plainTextToArrayBuffer(plainText: string): Promise<ArrayBuffer> {
+export function plainTextToArrayBuffer(plainText: string): ArrayBuffer {
   return new TextEncoder().encode(plainText);
 }
 
-export async function arrayBufferToPlainText(buffer: ArrayBuffer): Promise<string> {
+export function arrayBufferToPlainText(buffer: ArrayBuffer): string {
   return new TextDecoder().decode(buffer);
 }

--- a/src/lib/arrbuf-plain.ts
+++ b/src/lib/arrbuf-plain.ts
@@ -1,0 +1,7 @@
+export async function plainTextToArrayBuffer(plainText: string): Promise<ArrayBuffer> {
+  return new TextEncoder().encode(plainText);
+}
+
+export async function arrayBufferToPlainText(buffer: ArrayBuffer): Promise<string> {
+  return new TextDecoder().decode(buffer);
+}

--- a/src/lib/arrbuf-plain.ts
+++ b/src/lib/arrbuf-plain.ts
@@ -1,5 +1,5 @@
 export function plainTextToArrayBuffer(plainText: string): ArrayBuffer {
-  return new TextEncoder().encode(plainText);
+  return new TextEncoder().encode(plainText) as unknown as ArrayBuffer; // by-pass type check
 }
 
 export function arrayBufferToPlainText(buffer: ArrayBuffer): string {

--- a/src/lib/encrypt.ts
+++ b/src/lib/encrypt.ts
@@ -1,13 +1,13 @@
 import { arrayBufferToBase64, base64ToArrayBuffer } from "./arrbuf-b64";
 import { plainTextToArrayBuffer, arrayBufferToPlainText } from "./arrbuf-plain";
 
-const algorithm = { 
-  name: 'RSA-OAEP' 
+const algorithm = {
+  name: 'RSA-OAEP'
 } as const satisfies RsaOaepParams
 
-export async function encrypt(plainText: string, publicKey: CryptoKey): Promise<string> {  
+export async function encrypt(plainText: string, publicKey: CryptoKey): Promise<string> {
   const textBuf = await plainTextToArrayBuffer(plainText);
-  const cipherBuf = await crypto.subtle.encrypt(
+  const cipherBuf = await globalThis.crypto.subtle.encrypt(
     algorithm,
     publicKey,
     textBuf,
@@ -17,7 +17,7 @@ export async function encrypt(plainText: string, publicKey: CryptoKey): Promise<
 
 export async function decrypt(cipherText: string, privateKey: CryptoKey): Promise<string> {
   const cipherBuf = base64ToArrayBuffer(cipherText);
-  const textBuf = await crypto.subtle.decrypt(
+  const textBuf = await globalThis.crypto.subtle.decrypt(
     algorithm,
     privateKey,
     cipherBuf,

--- a/src/lib/encrypt.ts
+++ b/src/lib/encrypt.ts
@@ -1,0 +1,24 @@
+import { arrayBufferToBase64, base64ToArrayBuffer } from "./arrbuf-b64";
+import { plainTextToArrayBuffer, arrayBufferToPlainText } from "./arrbuf-plain";
+
+const algorithm = { name: 'RSA-OAEP' } as const
+
+export async function encrypt(plainText: string, publicKey: CryptoKey): Promise<string> {  
+  const textBuf = await plainTextToArrayBuffer(plainText);
+  const cipherBuf = await crypto.subtle.encrypt(
+    algorithm,
+    publicKey,
+    textBuf,
+  );
+  return arrayBufferToBase64(cipherBuf);
+}
+
+export async function decrypt(cipherText: string, privateKey: CryptoKey): Promise<string> {
+  const cipherBuf = base64ToArrayBuffer(cipherText);
+  const textBuf = await crypto.subtle.decrypt(
+    algorithm,
+    privateKey,
+    cipherBuf,
+  );
+  return arrayBufferToPlainText(textBuf);
+}

--- a/src/lib/encrypt.ts
+++ b/src/lib/encrypt.ts
@@ -1,7 +1,9 @@
 import { arrayBufferToBase64, base64ToArrayBuffer } from "./arrbuf-b64";
 import { plainTextToArrayBuffer, arrayBufferToPlainText } from "./arrbuf-plain";
 
-const algorithm = { name: 'RSA-OAEP' } as const
+const algorithm = { 
+  name: 'RSA-OAEP' 
+} as const satisfies RsaOaepParams
 
 export async function encrypt(plainText: string, publicKey: CryptoKey): Promise<string> {  
   const textBuf = await plainTextToArrayBuffer(plainText);

--- a/src/lib/import-export-key.ts
+++ b/src/lib/import-export-key.ts
@@ -1,38 +1,85 @@
 import { arrayBufferToBase64, base64ToArrayBuffer } from "./arrbuf-b64";
 
-const algorithm = {
+const oaepAlgorithm = {
   name: 'RSA-OAEP',
   hash: 'SHA-256'
 } as const satisfies RsaHashedImportParams;
 
-export async function exportPublicKey(key: CryptoKey): Promise<string> {
-  const exported = await globalThis.crypto.subtle.exportKey('spki', key);
+const pssAlgorithm = {
+  name: 'RSA-PSS',
+  saltLength: 32,
+} as const satisfies RsaPssParams;
+
+async function exportKey(keyFormat: 'spki' | 'pkcs8', key: CryptoKey): Promise<string>{
+  const exported = await globalThis.crypto.subtle.exportKey(keyFormat, key);
   return arrayBufferToBase64(exported);
 }
 
-export async function exportPrivateKey(key: CryptoKey): Promise<string> {
-  const exported = await globalThis.crypto.subtle.exportKey('pkcs8', key);
-  return arrayBufferToBase64(exported);
-}
-
-export async function importPublicKey(base64: string, extractable: boolean): Promise<CryptoKey> {
+function importKey(base64: string, options: {
+  keyFormat: 'spki' | 'pkcs8',
+  algorithm: RsaHashedImportParams | RsaPssParams,
+  extractable: boolean,
+  keyUsages: KeyUsage[],
+}): Promise<CryptoKey> {
   const keyData = base64ToArrayBuffer(base64);
   return globalThis.crypto.subtle.importKey(
-    'spki',
+    options.keyFormat,
     keyData,
-    algorithm,
-    extractable,
-    ['encrypt']
+    options.algorithm,
+    options.extractable,
+    options.keyUsages
   );
 }
 
-export async function importPrivateKey(base64: string, extractable: boolean): Promise<CryptoKey> {
-  const keyData = base64ToArrayBuffer(base64);
-  return globalThis.crypto.subtle.importKey(
-    'pkcs8',
-    keyData,
-    algorithm,
+export function exportPublicKey(key: CryptoKey): Promise<string> {
+  return exportKey('spki', key);
+}
+
+export function exportPrivateKey(key: CryptoKey): Promise<string> {
+  return exportKey('pkcs8', key);
+}
+
+// 署名でもやることは同じだが、念の為関数を分けておく
+export function exportSignKey(key: CryptoKey): Promise<string> {
+  return exportKey('spki', key);
+}
+
+export function exportVerifyKey(key: CryptoKey): Promise<string> {
+  return exportKey('pkcs8', key);
+}
+
+export function importPublicKey(base64: string, extractable: boolean): Promise<CryptoKey> {
+  return importKey(base64, {
+    keyFormat: 'spki',
+    algorithm: oaepAlgorithm,
     extractable,
-    ['decrypt']
-  );
+    keyUsages: ['encrypt']
+  })
+}
+
+export function importPrivateKey(base64: string, extractable: boolean): Promise<CryptoKey> {
+  return importKey(base64, {
+    keyFormat: 'pkcs8',
+    algorithm: oaepAlgorithm,
+    extractable,
+    keyUsages: ['decrypt']
+  })
+}
+
+export function importSignKey(base64: string, extractable: boolean): Promise<CryptoKey> {
+  return importKey(base64, {
+    keyFormat: 'pkcs8',
+    algorithm: pssAlgorithm,
+    extractable,
+    keyUsages: ['sign']
+  });
+}
+
+export function importVerifyKey(base64: string, extractable: boolean): Promise<CryptoKey> {
+  return importKey(base64, {
+    keyFormat: 'spki',
+    algorithm: pssAlgorithm,
+    extractable,
+    keyUsages: ['verify']
+  });
 }

--- a/src/lib/import-export-key.ts
+++ b/src/lib/import-export-key.ts
@@ -7,8 +7,8 @@ const oaepAlgorithm = {
 
 const pssAlgorithm = {
   name: 'RSA-PSS',
-  saltLength: 32,
-} as const satisfies RsaPssParams;
+  hash: 'SHA-256'
+} as const satisfies RsaHashedImportParams;
 
 async function exportKey(keyFormat: 'spki' | 'pkcs8', key: CryptoKey): Promise<string>{
   const exported = await globalThis.crypto.subtle.exportKey(keyFormat, key);
@@ -17,7 +17,7 @@ async function exportKey(keyFormat: 'spki' | 'pkcs8', key: CryptoKey): Promise<s
 
 function importKey(base64: string, options: {
   keyFormat: 'spki' | 'pkcs8',
-  algorithm: RsaHashedImportParams | RsaPssParams,
+  algorithm: RsaHashedImportParams,
   extractable: boolean,
   keyUsages: KeyUsage[],
 }): Promise<CryptoKey> {

--- a/src/lib/import-export-key.ts
+++ b/src/lib/import-export-key.ts
@@ -1,0 +1,38 @@
+import { arrayBufferToBase64, base64ToArrayBuffer } from "./arrbuf-b64";
+
+const algorithm = { 
+  name: 'RSA-OAEP', 
+  hash: 'SHA-256' 
+} as const satisfies RsaHashedImportParams;
+
+export async function exportPublicKey(key: CryptoKey): Promise<string> {
+  const exported = await crypto.subtle.exportKey('spki', key);
+  return arrayBufferToBase64(exported);
+}
+
+export async function exportPrivateKey(key: CryptoKey): Promise<string> {
+  const exported = await crypto.subtle.exportKey('pkcs8', key);
+  return arrayBufferToBase64(exported);
+}
+
+export async function importPublicKey(base64: string): Promise<CryptoKey> {
+  const keyData = base64ToArrayBuffer(base64);
+  return crypto.subtle.importKey(
+    'spki',
+    keyData,
+    algorithm,
+    true,
+    ['encrypt']
+  );
+}
+
+export async function importPrivateKey(base64: string): Promise<CryptoKey> {
+  const keyData = base64ToArrayBuffer(base64);
+  return crypto.subtle.importKey(
+    'pkcs8',
+    keyData,
+    algorithm,
+    true,
+    ['decrypt']
+  );
+}

--- a/src/lib/import-export-key.ts
+++ b/src/lib/import-export-key.ts
@@ -1,38 +1,38 @@
 import { arrayBufferToBase64, base64ToArrayBuffer } from "./arrbuf-b64";
 
-const algorithm = { 
-  name: 'RSA-OAEP', 
-  hash: 'SHA-256' 
+const algorithm = {
+  name: 'RSA-OAEP',
+  hash: 'SHA-256'
 } as const satisfies RsaHashedImportParams;
 
 export async function exportPublicKey(key: CryptoKey): Promise<string> {
-  const exported = await crypto.subtle.exportKey('spki', key);
+  const exported = await globalThis.crypto.subtle.exportKey('spki', key);
   return arrayBufferToBase64(exported);
 }
 
 export async function exportPrivateKey(key: CryptoKey): Promise<string> {
-  const exported = await crypto.subtle.exportKey('pkcs8', key);
+  const exported = await globalThis.crypto.subtle.exportKey('pkcs8', key);
   return arrayBufferToBase64(exported);
 }
 
-export async function importPublicKey(base64: string): Promise<CryptoKey> {
+export async function importPublicKey(base64: string, extractable: boolean): Promise<CryptoKey> {
   const keyData = base64ToArrayBuffer(base64);
-  return crypto.subtle.importKey(
+  return globalThis.crypto.subtle.importKey(
     'spki',
     keyData,
     algorithm,
-    true,
+    extractable,
     ['encrypt']
   );
 }
 
-export async function importPrivateKey(base64: string): Promise<CryptoKey> {
+export async function importPrivateKey(base64: string, extractable: boolean): Promise<CryptoKey> {
   const keyData = base64ToArrayBuffer(base64);
-  return crypto.subtle.importKey(
+  return globalThis.crypto.subtle.importKey(
     'pkcs8',
     keyData,
     algorithm,
-    true,
+    extractable,
     ['decrypt']
   );
 }

--- a/src/lib/sign.ts
+++ b/src/lib/sign.ts
@@ -1,0 +1,28 @@
+import { arrayBufferToBase64, base64ToArrayBuffer } from "./arrbuf-b64";
+import { plainTextToArrayBuffer } from "./arrbuf-plain";
+
+const algorithm = {
+  name: 'RSA-PSS',
+  saltLength: 32,
+} as const satisfies RsaPssParams;
+
+export async function sign(plainText: string, privateKey: CryptoKey): Promise<string> {
+  const textBuf = plainTextToArrayBuffer(plainText);
+  const signatureBuf = await globalThis.crypto.subtle.sign(
+    algorithm,
+    privateKey,
+    textBuf,
+  );
+  return arrayBufferToBase64(signatureBuf);
+}
+
+export async function verify(plainText: string, signature: string, publicKey: CryptoKey): Promise<boolean> {
+  const textBuf = plainTextToArrayBuffer(plainText);
+  const signatureBuf = base64ToArrayBuffer(signature);
+  return globalThis.crypto.subtle.verify(
+    algorithm,
+    publicKey,
+    signatureBuf,
+    textBuf,
+  );
+}


### PR DESCRIPTION
- 暗号化 / 復号に使う関数を追加
- 署名 / 検証用の関数を追加
- 鍵のインポート / エクスポート用関数を追加

なお、アルゴリズムは下記を使用している。
- 暗号化: RSA-OAEP
- 復号: RSA-PSS