### PR TITLE
metadataBaseの警告が出る問題を修正

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,14 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  env: {
+    URL: process.env.VERCEL_URL 
+      ? `https://${process.env.VERCEL_URL}`
+      : 'http://localhost:3000',
+    API_ENDPOINT: process.env.VERCEL_URL 
+      ? `https://${process.env.VERCEL_URL}/api`
+      : 'http://localhost:3000/api',
+  }
 };
 
 export default nextConfig;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -20,7 +20,7 @@ export const metadata: Metadata = {
   description: "暗号しか投稿できない匿名掲示板",
   openGraph: {
     images: [{
-      url: 'OGP.png'
+      url: `${process.env.URL}/OGP.png`,
     }]
   }
 };

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,6 +18,11 @@ export default async function Home({ searchParams }: {
           <Icones Icon={LockIcon} color="primary" position="left-of-text" />
           <span>暗号掲示板は現在準備中です</span>
         </p>
+        <div>
+          <h2>Environments</h2>
+          <p>{process.env.URL ?? 'undefined'}</p>
+          <p>{process.env.API_ENDPOINT ?? 'undefined'}</p>
+        </div>
         <p>
           <a href="https://github.com/nanasi-1/encrypted-board" target="_blank" className="text-secondary underline">GitHub</a>
         </p>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -18,11 +18,6 @@ export default async function Home({ searchParams }: {
           <Icones Icon={LockIcon} color="primary" position="left-of-text" />
           <span>暗号掲示板は現在準備中です</span>
         </p>
-        <div>
-          <h2>Environments</h2>
-          <p>{process.env.URL ?? 'undefined'}</p>
-          <p>{process.env.API_ENDPOINT ?? 'undefined'}</p>
-        </div>
         <p>
           <a href="https://github.com/nanasi-1/encrypted-board" target="_blank" className="text-secondary underline">GitHub</a>
         </p>


### PR DESCRIPTION
- `next.config.ts`に環境変数を追加
- `layout.tsx`のOGP画像のパスの設定を変更

OGP画像は**現在のデプロイメント**から持ってきたいかつ、絶対パスにする必要がある。
なので、`URL`環境変数を環境によって変え、それをOGP画像のパスに使うことで実装した。

`URL`:
- ローカル環境: `https://localhost:3000`
  - ローカルの開発サーバーのURL
  - `next.config.ts`で設定
- 本番 & プレビュー環境: [`VERCEL_URL`](https://vercel.com/docs/projects/environment-variables/system-environment-variables#VERCEL_URL)の値

close #19 