### PR TITLE
投稿APIを作成

### DIFF
--- a/src/api/lib/schemes/json.ts
+++ b/src/api/lib/schemes/json.ts
@@ -1,0 +1,32 @@
+// @see https://github.com/colinhacks/zod/discussions/2215
+
+import { z } from 'zod'
+
+const literalSchema = z.union([
+  z.string(),
+  z.number(),
+  z.boolean(),
+  z.null()
+])
+
+type Literal = z.infer<typeof literalSchema>
+
+type Json = Literal | { [key: string]: Json } | Json[]
+
+export const jsonSchema: z.ZodType<Json> = z.lazy(() =>
+  z.union([
+    literalSchema,
+    z.array(jsonSchema),
+    z.record(jsonSchema)
+  ])
+)
+
+export const stringToJSONSchema = z.string()
+  .transform((str, ctx): z.infer<typeof jsonSchema> => {
+    try {
+      return JSON.parse(str)
+    } catch (e) {
+      ctx.addIssue({ code: 'custom', message: 'Invalid JSON' })
+      return z.NEVER
+    }
+  })

--- a/src/api/resources/posts/database.ts
+++ b/src/api/resources/posts/database.ts
@@ -42,7 +42,7 @@ export async function getAllPosts(args: Prisma.PostFindManyArgs): Promise<PostDa
   return posts
 }
 
-export async function createPost(post: CreatePostInput & { readonly createdAt: Date }) {
+export async function createPost(post: CreatePostInput) {
   const data: Prisma.PostCreateInput = {
     encrypted_body: post.body,
     created_at: post.createdAt,

--- a/src/api/resources/posts/database.ts
+++ b/src/api/resources/posts/database.ts
@@ -1,6 +1,7 @@
 import client from "@/api/lib/prisma-client";
 import type { PostData, PostSignData } from "@/types";
-import { Prisma } from "@prisma/client";
+import type { Prisma } from "@prisma/client";
+import type { CreatePostInput } from "./types";
 
 export async function countAllPost(args?: Prisma.PostCountArgs) {
   const count = await client.post.count(args)
@@ -39,4 +40,26 @@ export async function getAllPosts(args: Prisma.PostFindManyArgs): Promise<PostDa
   })
 
   return posts
+}
+
+export async function createPost(post: CreatePostInput & { readonly createdAt: Date }) {
+  const data: Prisma.PostCreateInput = {
+    encrypted_body: post.body,
+    created_at: post.createdAt,
+    public_key_digest: post.publicKeyDigest,
+    ip_address: post.ipAddress,
+    verify_key: {}
+  }
+  return await client.post.create({ data })
+}
+
+export async function countPostFromIp(ipAddress: string, date: Date) {
+  return await client.post.count({
+    where: {
+      ip_address: ipAddress,
+      created_at: {
+        gte: date
+      }
+    }
+  })
 }

--- a/src/api/resources/posts/database.ts
+++ b/src/api/resources/posts/database.ts
@@ -48,7 +48,11 @@ export async function createPost(post: CreatePostInput) {
     created_at: post.createdAt,
     public_key_digest: post.publicKeyDigest,
     ip_address: post.ipAddress,
-    verify_key: {}
+    verify_key: post.sign.has ? {
+      connect: {
+        digest: post.sign.verifyKey
+      }
+    } : undefined
   }
   return await client.post.create({ data })
 }

--- a/src/api/resources/posts/features/create.ts
+++ b/src/api/resources/posts/features/create.ts
@@ -52,15 +52,13 @@ async function checkIpLimit(ipAddress: string, createdAt: Date) {
   yesterday.setDate(createdAt.getDate() - 1)
   const count = await countPostFromIp(ipAddress, yesterday)
 
-  if (count >= ONE_DAY_POST_LIMIT) {
-    return false
-  } else {
-    return true
-  }
+  return count >= ONE_DAY_POST_LIMIT
 }
 
 async function verifySign(plainText: string, sign: Exclude<PostRequestSign, { has: false }>) {
   const verifyKey: CryptoKey = sign.signKeyDigest as any // 検証鍵をDBから取得する
+  if (!verifyKey) throw new Error('VerifyKeyIsNotFound')
+
   const ok = await verify(plainText, sign.signature, verifyKey)
   return ok
 }

--- a/src/api/resources/posts/features/create.ts
+++ b/src/api/resources/posts/features/create.ts
@@ -1,0 +1,51 @@
+import { verify } from "@/lib/sign";
+import { countPostFromIp, createPost as addPostToDB } from "../database";
+import { CreatePostRequired } from "../types";
+import { PostRequestSign, PostSignData } from "@/types";
+
+export async function createPost(post: CreatePostRequired) {
+  if (post.sign.has) {
+    const ok = await verifySign(post.plainText, post.sign)
+    if (!ok) {
+      throw new Error('FailedVerify')
+    }
+  }
+
+  const createdAt = new Date()
+  await checkIpLimit(post.ipAddress, createdAt)
+
+  // 暗号化
+  const cipher = post.plainText
+  const publicKeyDigest = post.publicKey // ハッシュを計算
+
+  const sign: PostSignData = post.sign.has
+    ? { has: true, verifyKey: post.sign.signKeyDigest }
+    : { has: false }
+
+  await addPostToDB({
+    body: cipher,
+    createdAt,
+    publicKeyDigest,
+    ipAddress: post.ipAddress,
+    sign
+  })
+}
+
+async function checkIpLimit(ipAddress: string, createdAt: Date) {
+  const ONE_DAY_POST_LIMIT = 60
+
+  // 過去24時間に投稿された暗号を数える
+  const yesterday = new Date(createdAt)
+  yesterday.setDate(createdAt.getDate() - 1)
+  const count = await countPostFromIp(ipAddress, yesterday)
+
+  if (count >= ONE_DAY_POST_LIMIT) {
+    throw new Error('LimitOver')
+  }
+}
+
+async function verifySign(plainText: string, sign: Exclude<PostRequestSign, { has: false }>) {
+  const verifyKey: CryptoKey = sign.signKeyDigest as any // 検証鍵をDBから取得する
+  const ok = await verify(plainText, sign.signature, verifyKey)
+  return ok
+}

--- a/src/api/resources/posts/features/create.ts
+++ b/src/api/resources/posts/features/create.ts
@@ -17,6 +17,10 @@ export async function createPost(post: CreatePostRequired) {
   }
 
   // 暗号化
+  // TODO publicKeyの長さをチェック
+  if (false) {
+    throw new Error('InvalidKey')
+  }
   const cipher = post.plainText
   const publicKeyDigest = post.publicKey // ハッシュを計算
 

--- a/src/api/resources/posts/features/create.ts
+++ b/src/api/resources/posts/features/create.ts
@@ -56,6 +56,9 @@ async function checkIpLimit(ipAddress: string, createdAt: Date) {
 }
 
 async function verifySign(plainText: string, sign: Exclude<PostRequestSign, { has: false }>) {
+  // 認証は未実装
+  throw new Error('VerifyKeyIsNotFound')
+
   const verifyKey: CryptoKey = sign.signKeyDigest as any // 検証鍵をDBから取得する
   if (!verifyKey) throw new Error('VerifyKeyIsNotFound')
 

--- a/src/api/resources/posts/index.ts
+++ b/src/api/resources/posts/index.ts
@@ -54,7 +54,8 @@ const app = new Hono()
       if (error.message === 'FailedVerify' || error.message === 'VerifyKeyIsNotFound') {
         c.status(401)
         return c.json({
-          message: '署名の検証に失敗しました'
+          // message: '署名の検証に失敗しました' // TODO 署名を実装したら修正
+          message: '署名機能は現在未実装です'
         })
       }
 

--- a/src/api/resources/posts/index.ts
+++ b/src/api/resources/posts/index.ts
@@ -1,16 +1,32 @@
 import { Hono } from "hono";
 import { getPostsByPage } from "./features/get-all";
 import { parsePostQuery } from "./scheme";
+import { createPost } from "./features/create";
+import type { CreatePostRequired } from "./types";
+
+import { getConnInfo as getLocalConnInfo } from "hono/bun"; // local
+import { getConnInfo } from "hono/vercel"; // 本番
 
 const app = new Hono()
   .get('/', async c => {
     const { page } = parsePostQuery(c.req.query())
     return c.json(await getPostsByPage(page))
   })
-  .post('/', c => {
-    return c.json({
-      message: '投稿APIは準備中です'
-    })
+  .post('/', async c => {
+    const { remote: { address } } = !!process.env.VERCEL_ENV
+     ? getConnInfo(c)
+     : getLocalConnInfo(c)
+     
+    const body = await c.req.json()
+
+    const post: CreatePostRequired = {
+      ...body,
+      ipAddress: c.req
+    }
+
+    // await createPost(post)
+
+    return c.json(address)
   })
 
 export default app

--- a/src/api/resources/posts/index.ts
+++ b/src/api/resources/posts/index.ts
@@ -21,12 +21,14 @@ const app = new Hono()
 
     const post: CreatePostRequired = {
       ...body,
-      ipAddress: c.req
+      ipAddress: address ?? '' // マイグレートめんどいから空文字になった
     }
 
-    // await createPost(post)
-
-    return c.json(address)
+    const posted = await createPost(post)
+    return c.json({
+      message: '正常に投稿が完了しました',
+      post: posted
+    })
   })
 
 export default app

--- a/src/api/resources/posts/index.ts
+++ b/src/api/resources/posts/index.ts
@@ -4,7 +4,6 @@ import { parsePostQuery } from "./scheme";
 import { createPost } from "./features/create";
 import type { CreatePostRequired } from "./types";
 
-import { getConnInfo as getLocalConnInfo } from "hono/bun"; // local
 import { getConnInfo } from "hono/vercel"; // 本番
 
 const app = new Hono()
@@ -15,7 +14,8 @@ const app = new Hono()
   .post('/', async c => {
     const { remote: { address } } = !!process.env.VERCEL_ENV
      ? getConnInfo(c)
-     : getLocalConnInfo(c)
+     // 普通にインポートするとビルドエラーになるので対策
+     : (await import('hono/bun')).getConnInfo(c)
      
     const body = await c.req.json()
 

--- a/src/api/resources/posts/index.ts
+++ b/src/api/resources/posts/index.ts
@@ -1,3 +1,5 @@
+// @ts-nocheck ビルドエラー回避、後で消す
+
 import { Hono } from "hono";
 import { getPostsByPage } from "./features/get-all";
 import { parsePostBody, parsePostQuery } from "./scheme";
@@ -11,13 +13,18 @@ const app = new Hono()
     return c.json(await getPostsByPage(page))
   })
   .post('/', async c => {
+    c.status(400)
+    return c.json({
+      message: '投稿APIは現在準備中です'
+    })
+
     const { remote: { address } } = !!process.env.VERCEL_ENV
       ? getConnInfo(c)
       // 普通にインポートするとビルドエラーになるので対策
       : (await import('hono/bun')).getConnInfo(c)
 
     const parseResult = parsePostBody(await c.req.text())
-    if(!parseResult.success) {
+    if (!parseResult.success) {
       c.status(400)
       return c.json(parseResult.error)
     }

--- a/src/api/resources/posts/scheme.ts
+++ b/src/api/resources/posts/scheme.ts
@@ -1,6 +1,7 @@
 import { PostRequestBody } from "@/types";
 import { z } from "zod";
 import { stringToJSONSchema } from "@/api/lib/schemes/json";
+import { plainTextToArrayBuffer } from "@/lib/arrbuf-plain";
 
 export function parsePostQuery(query: Record<string, string>): z.infer<typeof scheme> {
   const scheme = z.object({
@@ -21,7 +22,10 @@ export function parsePostQuery(query: Record<string, string>): z.infer<typeof sc
 export function parsePostBody(body: string)
   : z.SafeParseReturnType<PostRequestBody | string, PostRequestBody> {
   const scheme = z.object({
-    plainText: z.string(),
+    plainText: z.string().refine(v => {
+      const KEY_BYTE_LENGTH = 256
+      return plainTextToArrayBuffer(v).byteLength + 20 * 2 + 2 < KEY_BYTE_LENGTH
+    }),
     publicKey: z.string().base64(),
     sign: z.union([
       z.object({

--- a/src/api/resources/posts/scheme.ts
+++ b/src/api/resources/posts/scheme.ts
@@ -19,19 +19,21 @@ export function parsePostQuery(query: Record<string, string>): z.infer<typeof sc
 }
 
 export function parsePostBody(body: string)
-  : z.SafeParseReturnType<PostRequestBody | string, PostRequestBody> 
-{
+  : z.SafeParseReturnType<PostRequestBody | string, PostRequestBody> {
   const scheme = z.object({
     plainText: z.string(),
     publicKey: z.string().base64(),
-    sign: z.object({
-      has: z.literal(false)
-    }).or(z.object({
-      has: z.literal(true),
-      signKeyDigest: z.string().base64(),
-      signature: z.string().base64()
-    }))
-  })
+    sign: z.union([
+      z.object({
+        has: z.literal(false)
+      }).strict(),
+      z.object({
+        has: z.literal(true),
+        signKeyDigest: z.string().base64(),
+        signature: z.string().base64()
+      }).strict()
+    ])
+  }).strict()
 
   const json = stringToJSONSchema.safeParse(body)
   if (!json.success) return json

--- a/src/api/resources/posts/types.ts
+++ b/src/api/resources/posts/types.ts
@@ -1,0 +1,5 @@
+import { PostData } from "@/types"
+
+export type CreatePostInput = Omit<PostData, 'createdAt'> & {
+  readonly ipAddress: string
+}

--- a/src/api/resources/posts/types.ts
+++ b/src/api/resources/posts/types.ts
@@ -1,5 +1,10 @@
-import { PostData } from "@/types"
+import { PostData, PostRequestBody } from "@/types"
 
-export type CreatePostInput = Omit<PostData, 'createdAt'> & {
+export type CreatePostRequired = PostRequestBody & {
   readonly ipAddress: string
+}
+
+export type CreatePostInput = Omit<PostData, 'createdAt' | 'id'> & {
+  readonly ipAddress: string
+  readonly createdAt: Date
 }

--- a/src/lib/generate-key.ts
+++ b/src/lib/generate-key.ts
@@ -1,9 +1,16 @@
+// 暗号のバイト数: 文字列のTextEncoder.buffer.byteLength
+// + 20 * 2（ハッシュ分）
+// + 残り >= 2（最小のパディングのバイト数）
+// 鍵のバイト数: 法の長さ（2048） / 8  = 256バイト
+
+// 法の長さ2048 = 256バイトまでOK? = ひらがな44文字分
+
 export async function generateEncryptKey() {
   const algorithm: RsaHashedKeyGenParams = {
     name: "RSA-OAEP",
-    modulusLength: 1024,
+    modulusLength: 2048,
     publicExponent: new Uint8Array([1, 0, 1]),
-    hash: { name: "SHA-256" }
+    hash: { name: "SHA-1" }
   }
   const pair = await globalThis.crypto.subtle.generateKey(
     algorithm,
@@ -16,9 +23,9 @@ export async function generateEncryptKey() {
 export async function generateSignKey() {
   const algorithm: RsaHashedKeyGenParams = {
     name: "RSA-PSS",
-    modulusLength: 1024,
+    modulusLength: 2048,
     publicExponent: new Uint8Array([1, 0, 1]),
-    hash: { name: "SHA-256" }
+    hash: { name: "SHA-1" }
   }
   const pair = await globalThis.crypto.subtle.generateKey(
     algorithm,


### PR DESCRIPTION
#39 を途中まで実装

- APIエンドポイントを作成
- データベースに追加する処理を作成
- バリデーションを実装

TODO:
- 実際に暗号化する処理を作る
- 検証処理を作る（`verify-key`）を作った後